### PR TITLE
fix: keep websocket sessions alive

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -422,6 +422,8 @@ app.get('/api/projects/:projectName/files', authenticateToken, async (req, res) 
 
 // WebSocket connection handler that routes based on URL path
 wss.on('connection', (ws, request) => {
+  ws.isAlive = true;
+  ws.on('pong', heartbeat);
   const {url} = request;
   // console.log('🔗 Client connected to:', url);
   // Parse URL to get pathname without query parameters
@@ -446,6 +448,10 @@ function handleChatConnection(ws) {
   ws.on('message', async (message) => {
     try {
       const data = JSON.parse(message);
+      if (data.type === 'ping') {
+        ws.send(JSON.stringify({ type: 'pong' }));
+        return;
+      }
       if (data.type === 'gemini-command') {
         // console.log('💬 User message:', data.command || '[Continue/Resume]');
         // console.log('📁 Project:', data.options?.projectPath || 'Unknown');


### PR DESCRIPTION
## Summary
- handle WebSocket pong frames so server heartbeat doesn't kill active sessions
- reply to client ping messages and add heartbeat/reconnect logic in `useWebSocket`

## Testing
- `npx eslint server/index.js src/utils/websocket.js` *(fails: numerous existing lint errors)*
- `npx eslint src/utils/websocket.js` *(warns: React hook missing deps)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7bd5167f0832c9266c23cd9c7b72c