### PR TITLE
Fix newline handling in streamed chat responses

### DIFF
--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -262,13 +262,14 @@ async function spawnGemini(command, options = {}, ws) {
         return true;
       });
       
-      const filteredOutput = filteredLines.join('\n').trim();
+      // Join lines without trimming to preserve spacing across streamed chunks
+      const filteredOutput = filteredLines.join('\n');
       
       if (filteredOutput) {
         // Debug - Gemini response
         
-        // Accumulate the full response
-        fullResponse += (fullResponse ? '\n' : '') + filteredOutput;
+        // Accumulate the full response without inserting extra newlines
+        fullResponse += filteredOutput;
         
         // Send the filtered output as a message
         ws.send(JSON.stringify({

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1530,21 +1530,39 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
                   toolResult: null // Will be updated when result comes in
                 }]);
               } else if (part.type === 'text' && part.text?.trim()) {
-                // Add regular text message
-                setChatMessages(prev => [...prev, {
-                  type: 'assistant',
-                  content: part.text,
-                  timestamp: new Date()
-                }]);
+                // Append streaming text to the last assistant message if possible
+                setChatMessages(prev => {
+                  const updated = [...prev];
+                  const last = updated[updated.length - 1];
+                  if (last && last.type === 'assistant' && !last.isToolUse) {
+                    last.content += part.text;
+                  } else {
+                    updated.push({
+                      type: 'assistant',
+                      content: part.text,
+                      timestamp: new Date()
+                    });
+                  }
+                  return updated;
+                });
               }
             }
           } else if (typeof messageData.content === 'string' && messageData.content.trim()) {
-            // Add regular text message
-            setChatMessages(prev => [...prev, {
-              type: 'assistant',
-              content: messageData.content,
-              timestamp: new Date()
-            }]);
+            // Append streaming text to the last assistant message if possible
+            setChatMessages(prev => {
+              const updated = [...prev];
+              const last = updated[updated.length - 1];
+              if (last && last.type === 'assistant' && !last.isToolUse) {
+                last.content += messageData.content;
+              } else {
+                updated.push({
+                  type: 'assistant',
+                  content: messageData.content,
+                  timestamp: new Date()
+                });
+              }
+              return updated;
+            });
           }
           // Handle tool results from user messages (these come separately)
           if (messageData.role === 'user' && Array.isArray(messageData.content)) {


### PR DESCRIPTION
## Summary
- preserve whitespace when collecting Gemini CLI output
- append streamed Gemini text to the latest assistant message instead of creating new messages

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aee739a724832cb7c25bc70bff9adb