### PR TITLE
Fix newline handling and auto-scroll in streamed chat responses

### DIFF
--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -262,13 +262,14 @@ async function spawnGemini(command, options = {}, ws) {
         return true;
       });
       
-      const filteredOutput = filteredLines.join('\n').trim();
+      // Join lines without trimming to preserve spacing across streamed chunks
+      const filteredOutput = filteredLines.join('\n');
       
       if (filteredOutput) {
         // Debug - Gemini response
         
-        // Accumulate the full response
-        fullResponse += (fullResponse ? '\n' : '') + filteredOutput;
+        // Accumulate the full response without inserting extra newlines
+        fullResponse += filteredOutput;
         
         // Send the filtered output as a message
         ws.send(JSON.stringify({


### PR DESCRIPTION
## Summary
- preserve whitespace when collecting Gemini CLI output
- append streamed Gemini text to the latest assistant message instead of creating a new message for each chunk
- keep chat view scrolled to the newest streamed content until the user scrolls up

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint src/components/ChatInterface.jsx` *(fails: 'index' is defined but never used, and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aee739a724832cb7c25bc70bff9adb