### PR TITLE
fix: pause auto-scroll when user scrolls

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1296,23 +1296,23 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
     }
   }, []);
 
-  // Check if user is near the bottom of the scroll container
-  const isNearBottom = useCallback(() => {
+  // Check if user is at the bottom of the scroll container
+  const isAtBottom = useCallback(() => {
     if (!scrollContainerRef.current) {
       return false;
     }
     const { scrollTop, scrollHeight, clientHeight } = scrollContainerRef.current;
-    // Consider "near bottom" if within 50px of the bottom
-    return scrollHeight - scrollTop - clientHeight < 50;
+    // Treat as bottom only when the user is effectively at the end
+    return Math.abs(scrollHeight - scrollTop - clientHeight) <= 1;
   }, []);
 
-  // Handle scroll events to detect when user manually scrolls up
+  // Handle scroll events to detect when user manually scrolls away from the bottom
   const handleScroll = useCallback(() => {
     if (scrollContainerRef.current) {
-      const nearBottom = isNearBottom();
-      setIsAutoScrollPaused(!nearBottom);
+      const atBottom = isAtBottom();
+      setIsAutoScrollPaused(!atBottom);
     }
-  }, [isNearBottom]);
+  }, [isAtBottom]);
 
   // Track previous session ID using useRef to properly detect session changes
   const previousSessionIdRef = useRef(null);
@@ -1789,9 +1789,9 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
     return chatMessages.slice(-visibleMessageCount);
   }, [chatMessages, visibleMessageCount]);
 
-  // Capture scroll position before render when auto-scroll is disabled
+  // Capture scroll position before render when auto-scroll is disabled or paused
   useEffect(() => {
-    if (!autoScrollToBottom && scrollContainerRef.current) {
+    if ((isAutoScrollPaused || !autoScrollToBottom) && scrollContainerRef.current) {
       const container = scrollContainerRef.current;
       scrollPositionRef.current = {
         height: container.scrollHeight,
@@ -1801,21 +1801,16 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
   });
 
   useEffect(() => {
-    // Auto-scroll to bottom when new messages arrive
+    // Maintain scroll position or auto-scroll depending on user interaction
     if (scrollContainerRef.current && chatMessages.length > 0) {
-      if (autoScrollToBottom) {
-        // If auto-scroll is enabled, always scroll to bottom unless user has manually scrolled up
-        if (!isAutoScrollPaused) {
-          setTimeout(() => scrollToBottom(), 50); // Small delay to ensure DOM is updated
-        }
+      if (autoScrollToBottom && !isAutoScrollPaused) {
+        setTimeout(() => scrollToBottom(), 50); // Small delay to ensure DOM is updated
       } else {
-        // When auto-scroll is disabled, preserve the visual position
         const container = scrollContainerRef.current;
         const prevHeight = scrollPositionRef.current.height;
         const prevTop = scrollPositionRef.current.top;
         const newHeight = container.scrollHeight;
         const heightDiff = newHeight - prevHeight;
-        // If content was added above the current view, adjust scroll position
         if (heightDiff > 0 && prevTop > 0) {
           container.scrollTop = prevTop + heightDiff;
         }


### PR DESCRIPTION
## Summary
- Prevent chat auto-scroll when user manually scrolls away from bottom
- Preserve scroll position during streaming updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/ChatInterface.jsx` *(fails: existing lint errors in file)*

------
https://chatgpt.com/codex/tasks/task_e_68aef4e55c34832caff8277b086333dc