### PR TITLE
fix: stabilize auto-scroll during streaming

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,7 +18,7 @@
  * Handles both existing sessions (with real IDs) and new sessions (with temporary IDs).
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, useNavigate, useParams } from 'react-router-dom';
 import Sidebar from './components/Sidebar';
 import MainContent from './components/MainContent';

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -11,7 +11,7 @@
  * No session protection logic is implemented here - it's purely a props bridge.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import ChatInterface from './ChatInterface';
 import FileTree from './FileTree';
 import CodeEditor from './CodeEditor';
@@ -335,6 +335,7 @@ function MainContent({
         <div className={`h-full overflow-hidden ${activeTab === 'editor' ? 'block' : 'hidden'}`}>
           <EditorTab
             selectedProject={selectedProject}
+            selectedSession={selectedSession}
             ws={ws}
             sendMessage={sendMessage}
             messages={messages}


### PR DESCRIPTION
## Summary
- ignore programmatic scroll events to prevent jitter and keep manual scroll position intact
- drop unused `ws` prop from ChatInterface and related components
- restore `ws` prop across chat components to retain direct WebSocket access

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/App.jsx src/components/MainContent.jsx src/components/EditorTab.jsx src/components/ChatSidebar.jsx src/components/ChatInterface.jsx` *(warnings: react-hooks/exhaustive-deps)*

------
https://chatgpt.com/codex/tasks/task_e_68aef4e55c34832caff8277b086333dc