### PR TITLE
fix: prevent chat auto-scroll jitter

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1301,15 +1301,17 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
       return false;
     }
     const { scrollTop, scrollHeight, clientHeight } = scrollContainerRef.current;
-    // Treat as bottom only when the user is effectively at the end
-    return Math.abs(scrollHeight - scrollTop - clientHeight) <= 1;
+    // Allow small threshold to account for sub-pixel rendering
+    return Math.abs(scrollHeight - scrollTop - clientHeight) <= 5;
   }, []);
 
   // Handle scroll events to detect when user manually scrolls away from the bottom
   const handleScroll = useCallback(() => {
-    if (scrollContainerRef.current) {
-      const atBottom = isAtBottom();
-      setIsAutoScrollPaused(!atBottom);
+    if (!scrollContainerRef.current) {
+      return;
+    }
+    if (!isAtBottom()) {
+      setIsAutoScrollPaused(true);
     }
   }, [isAtBottom]);
 


### PR DESCRIPTION
## Summary
- stabilize chat autoscroll by tolerating tiny offsets from the bottom
- only pause autoscroll when user scrolls away, avoiding jittery jumps

## Testing
- `npx eslint src/components/ChatInterface.jsx` *(fails: multiple existing no-unused-vars and hooks dependency warnings)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aefda79998832cb18806b884546102