### PR TITLE
Fix auto-scroll not resuming after manual scroll

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1310,7 +1310,9 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
     if (!scrollContainerRef.current) {
       return;
     }
-    if (!isAtBottom()) {
+    if (isAtBottom()) {
+      setIsAutoScrollPaused(false);
+    } else {
       setIsAutoScrollPaused(true);
     }
   }, [isAtBottom]);


### PR DESCRIPTION
## Summary
- ensure chat auto-scroll resumes when user returns to bottom

## Testing
- `npm test` (fails: Missing script "test")
- `npx eslint src/components/ChatInterface.jsx` (fails: no-unused-vars etc.)

------
https://chatgpt.com/codex/tasks/task_e_68aeff061130832cb63b4adb43cb6a39