### PR TITLE
fix: avoid timestamps in copied chat text

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -97,7 +97,10 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
                 ))}
               </div>
             )}
-            <div className="text-xs text-gemini-100 mt-1 text-right">
+            <div
+              className="text-xs text-gemini-100 mt-1 text-right select-none pointer-events-none"
+              aria-hidden="true"
+            >
               {new Date(message.timestamp).toLocaleTimeString()}
             </div>
           </div>
@@ -982,7 +985,10 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
               </div>
             )}
 
-            <div className={`text-xs text-gray-500 dark:text-gray-400 mt-1 ${isGrouped ? 'opacity-0 group-hover:opacity-100' : ''}`}>
+            <div
+              className={`text-xs text-gray-500 dark:text-gray-400 mt-1 ${isGrouped ? 'opacity-0 group-hover:opacity-100' : ''} select-none pointer-events-none`}
+              aria-hidden="true"
+            >
               {new Date(message.timestamp).toLocaleTimeString()}
             </div>
           </div>

--- a/src/components/ui/ToolUseFeedback.jsx
+++ b/src/components/ui/ToolUseFeedback.jsx
@@ -295,7 +295,12 @@ function ToolUseFeedback({
       <div className="flex items-center gap-2">
         {headerIcon}
         <div className="text-sm font-medium text-zinc-900 dark:text-zinc-50">{toolName}</div>
-        <div className="text-xs text-zinc-500 dark:text-zinc-400">{timestampText}</div>
+        <div
+          className="text-xs text-zinc-500 dark:text-zinc-400 select-none pointer-events-none"
+          aria-hidden="true"
+        >
+          {timestampText}
+        </div>
         {onShowSettings ? (
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary
- mark chat and tool timestamps as unselectable to prevent time strings from appearing when copying messages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npx eslint src/components/ChatInterface.jsx src/components/ui/ToolUseFeedback.jsx` *(fails: no-unused-vars and react-hooks warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68be8ca303a0832cb0ebd5589997d2b0